### PR TITLE
Fix fatal error when writing to utf8 file

### DIFF
--- a/lib/Minecraft/Projection.pm
+++ b/lib/Minecraft/Projection.pm
@@ -53,7 +53,7 @@ sub write_status {
 
 	my $filename = $self->{world}->{dir}."/map-maker-status.json";
 	open( my $fh, ">:utf8", $filename ) || die "failed to open (for writing) $filename: $!";
-  	syswrite( $fh, encode_json( $self->{opts} ));
+  	print $fh encode_json( $self->{opts} );
   	close $fh;
 }
 


### PR DESCRIPTION
Fixes ```syswrite() isn't allowed on :utf8 handles at /home/mattia/geocraft/lib/Minecraft/Projection.pm line 56``` error when running Perl 5.30